### PR TITLE
updated version of libxmljs dependency (0.7 fails to node-gyp rebuild )

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Phil Jackson <phil@apiaxle.com> (http://apiaxle.com)",
   "name": "js2xml",
   "description": "Convert arbitary javascript to simple XML. Developed for ApiAxle.",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "./lib/js2xml",
   "repository": {
     "url": ""
@@ -29,7 +29,7 @@
     "node": ">0.4"
   },
   "dependencies": {
-    "libxmljs": "0.7"
+    "libxmljs": "0.8.1"
   },
   "devDependencies": {
     "coffee-script": "~1"


### PR DESCRIPTION
Hi

Node-gyp fails to build 0.7.\* versions of libxmljs
I have updated version of linked libxmljs version

Thx in advance
