### PR TITLE
use last version of libxmljs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">0.8"
   },
   "dependencies": {
-    "libxmljs": "0.13.0"
+    "libxmljs": "~0.x"
   },
   "devDependencies": {
     "coffee-script": "~1"


### PR DESCRIPTION
The version `0.13.0` of the libxmljs throw many errors in the installation like:

```
npm ERR! libxmljs@0.13.0 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the libxmljs@0.13.0 install script 'node-gyp rebuild'.
```
This erros have been resolved in `0.14.0  version, but I want to update the dependency match to use the last version possible to prevent similar behavior in the future.