### PR TITLE
libxmljs 0.14.0 -> 0.14.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">0.8"
   },
   "dependencies": {
-    "libxmljs": "0.14.0"
+    "libxmljs": "~0.14.0"
   },
   "devDependencies": {
     "coffee-script": "~1"


### PR DESCRIPTION
libxmljs 0.14.0 not build on node 4.x
```
make: *** [Release/obj.target/xmljs/src/libxmljs.o] Error 1
make: Leaving directory `/xxx/node_modules/js2xml/node_modules/libxmljs/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/xxx/.nvm/versions/node/v4.1.1/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:270:23)
gyp ERR! stack     at emitTwo (events.js:87:13)
gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Linux 3.13.0-63-generic
gyp ERR! command "/xxx/.nvm/versions/node/v4.1.1/bin/node" "/xxx/.nvm/versions/node/v4.1.1/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /xxx/node_modules/js2xml/node_modules/libxmljs
gyp ERR! node -v v4.1.1
gyp ERR! node-gyp -v v3.0.3
gyp ERR! not ok 
npm ERR! Linux 3.13.0-63-generic
npm ERR! argv "/xxx/.nvm/versions/node/v4.1.1/bin/node" "/xxx/.nvm/versions/node/v4.1.1/bin/npm" "install" "js2xml"
npm ERR! node v4.1.1
npm ERR! npm  v2.14.4
npm ERR! code ELIFECYCLE

npm ERR! libxmljs@0.14.0 install: `node-gyp rebuild`
npm ERR! Exit status 1
```
last version libxmljs 0.14.3 build ok
```
make: Leaving directory `/xxx/node_modules/js2xml/node_modules/libxmljs/build'
js2xml@1.0.3 node_modules/js2xml
└── libxmljs@0.14.3 (bindings@1.2.1, nan@2.0.7)
```