### PR TITLE
update libxmljs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">0.8"
   },
   "dependencies": {
-    "libxmljs": "~0.14.0"
+    "libxmljs": "~0.18.0"
   },
   "devDependencies": {
     "coffee-script": "~1"


### PR DESCRIPTION
This PR updates the version of `libxmljs` from 0.14 to 0.18.
0.14 doesn't build build anymore with latest libxml/node/clang.