### PR TITLE
Update "libxmljs": "0.18.4" dependence to at least "0.19.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node": ">0.8"
   },
   "dependencies": {
-    "libxmljs": "0.18.4"
+    "libxmljs": "^0.19.1"
   },
   "devDependencies": {
     "coffee-script": "1"


### PR DESCRIPTION
This will be update the 'hoek' dependence to a new version.
hoek node module before 4.2.0 and 5.0.x before 5.0.3 suffers from a Modification of Assumed-Immutable Data (MAID) vulnerability via 'merge' and 'applyToDefaults' functions, which allows a malicious user to modify the prototype of "Object" via proto, causing the addition or modification of an existing property that will exist on all objects.

https://nvd.nist.gov/vuln/detail/CVE-2018-3728